### PR TITLE
Refactor: 바이너리 인코딩 스캔 순서 변경

### DIFF
--- a/src/main/java/com/digital_tok/image/service/processing/EinkBinaryEncoder.java
+++ b/src/main/java/com/digital_tok/image/service/processing/EinkBinaryEncoder.java
@@ -37,7 +37,9 @@ public class EinkBinaryEncoder {
 
         byte[] out = new byte[expectedBytes];
 
-        // 세로 스캔: x=0..width-1, y=0..height-1 순으로 픽셀을 읽는다.
+        // scanDirection에 따라 픽셀 스캔 순서를 결정한다.
+        // - HORIZONTAL: row-major (y=0.., x=0..)
+        // - VERTICAL  : column-major (x=0.., y=0..)
         // 4픽셀(2bit*4=8bit)을 1바이트로 패킹:
         // byte = (p0<<6) | (p1<<4) | (p2<<2) | (p3)
         int outIndex = 0;

--- a/src/main/java/com/digital_tok/image/service/processing/EinkEncodingOption.java
+++ b/src/main/java/com/digital_tok/image/service/processing/EinkEncodingOption.java
@@ -18,7 +18,8 @@ public class EinkEncodingOption {
     public EinkEncodingOption() {
         this.width = DEFAULT_WIDTH;
         this.height = DEFAULT_HEIGHT;
-        this.scanDirection = ScanDirection.VERTICAL;
+        this.scanDirection = ScanDirection.HORIZONTAL;
+
     }
 
     public int getWidth() {


### PR DESCRIPTION
## 📋 작업 내용
안드로이드팀 요청에 맞춰 **E-ink 바이너리 인코딩 스캔 순서를 row-major(가로 스캔)** 로 변경했습니다.  
기존에 payload는 column-major로 생성되었지만 응답 meta는 row-major로 내려가 불일치가 발생할 수 있어, **기본 인코딩 방향을 row-major로 통일**했습니다.

## 🔗 관련 이슈 (Issue)
Closes #82 

## 🛠️ 주요 변경 사항

### 1. E-ink 바이너리 인코딩 기본 스캔 방향 변경 (column-major → row-major)

- `EinkEncodingOption`의 기본 `scanDirection`을 `VERTICAL` → `HORIZONTAL`로 변경하여
  `EinkBinaryEncoder`가 **row-major(가로 스캔)** 경로로 동작하도록 수정했습니다.

#### 변경 파일
- `src/main/java/com/digital_tok/image/service/processing/EinkEncodingOption.java`


## 🧪 테스트 결과
## ✅ 체크리스트
- [ ] 1 :  추후 안드로이드팀에서 기기로 테스트 예정
