### PR TITLE
Fix: 로그아웃 할 때 refreshToken 입력시 서버에서 발생

### DIFF
--- a/src/main/java/com/digital_tok/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/digital_tok/global/security/JwtTokenProvider.java
@@ -56,6 +56,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(String.valueOf(userId)) // 리프레시 토큰은 유저 ID만 담음
+                .claim("userId", userId) // Refresh Token도 userId를 claim 으로 받도록 수정
                 .issuedAt(now)
                 .expiration(validity)
                 .signWith(key)


### PR DESCRIPTION
## 📋 작업 내용
Refresh Token 생성할때 userId를 claim 으로 넣어주게 수정

## 🔗 관련 이슈 (Issue)
Closes #88 


## 🧪 테스트 결과
## ✅ 체크리스트
- [x] 로그아웃 할 때 refreshToken 입력시 정상 로그아웃 및 DB 토큰 삭제 확인