### PR TITLE
Fix: binary 변환 로직에서 이미지의 패킹 밀림 현상 해결

### DIFF
--- a/src/main/java/com/digital_tok/image/service/processing/EinkBinaryEncoder.java
+++ b/src/main/java/com/digital_tok/image/service/processing/EinkBinaryEncoder.java
@@ -58,12 +58,12 @@ public class EinkBinaryEncoder {
         } else {
             // 가로 스캔: y=0..height-1, x=0..width-1
             for (int y = 0; y < height; y++) {
-                // 좌우 반전 보정: x를 오른쪽→왼쪽으로 스캔
+                // 좌우 반전 보정: x를 오른쪽→왼쪽으로 스캔, 패킹 밀림 현상 해결
                 for (int x = width - 4; x >= 0; x -= 4) {
-                    int p0 = to2BitColorCode(quantized200x200.getRGB(x, y));
-                    int p1 = to2BitColorCode(quantized200x200.getRGB(x + 1, y));
-                    int p2 = to2BitColorCode(quantized200x200.getRGB(x + 2, y));
-                    int p3 = to2BitColorCode(quantized200x200.getRGB(x + 3, y));
+                    int p0 = to2BitColorCode(quantized200x200.getRGB(x + 3, y));
+                    int p1 = to2BitColorCode(quantized200x200.getRGB(x + 2, y));
+                    int p2 = to2BitColorCode(quantized200x200.getRGB(x + 1, y));
+                    int p3 = to2BitColorCode(quantized200x200.getRGB(x, y));
                     out[outIndex++] = pack4(p0, p1, p2, p3);
                 }
             }


### PR DESCRIPTION
## 📋 작업 내용
이미지를 기기에 띄웠을 때 한 패킹 내에서 반전이 되어서 밀려보이는 듯한 현상을 해결했습니다.
## 🔗 관련 이슈 (Issue)
Closes #90 


## 🧪 테스트 결과
## ✅ 체크리스트
- [ ] 1 : 프론트엔드에서 기기로 직접 확인해보실 예정입니다
