### PR TITLE
Fix: 회원 탈퇴한 이메일 복구 예외처리 추가

### DIFF
--- a/src/main/java/com/digital_tok/auth/service/AuthService.java
+++ b/src/main/java/com/digital_tok/auth/service/AuthService.java
@@ -149,12 +149,22 @@ public class AuthService {
 
     /**
      * 4. 이메일 중복 검사 (API용)
-     * 사용 가능한 이메일이면 통과, 중복이면 예외 발생
      */
     public void checkEmailDuplicate(String email) {
-        if (userRepository.existsByEmail(email)) {
+        // 이메일로 유저 정보 조회
+        Optional<User> user = userRepository.findByEmail(email);
+
+        if (user.isPresent()) {
+            // 탈퇴한(INACTIVE) 유저인 경우 별도 예외 처리
+            if (user.get().getStatus() == UserStatus.INACTIVE) {
+                throw new GeneralException(ErrorCode.MEMBER_INACTIVE);
+            }
+
+            // 그 외(ACTIVE, BLOCKED 등)는 이미 가입된 사용자로 처리
             throw new GeneralException(ErrorCode.MEMBER_ALREADY_REGISTERED);
         }
+
+        // user가 없으면 중복 아님 -> 통과
     }
 
     /**

--- a/src/main/java/com/digital_tok/auth/service/AuthService.java
+++ b/src/main/java/com/digital_tok/auth/service/AuthService.java
@@ -151,20 +151,16 @@ public class AuthService {
      * 4. 이메일 중복 검사 (API용)
      */
     public void checkEmailDuplicate(String email) {
-        // 이메일로 유저 정보 조회
+        // 1. 이메일로 유저 조회 (User 객체를 가져옴)
         Optional<User> user = userRepository.findByEmail(email);
 
-        if (user.isPresent()) {
-            // 탈퇴한(INACTIVE) 유저인 경우 별도 예외 처리
-            if (user.get().getStatus() == UserStatus.INACTIVE) {
-                throw new GeneralException(ErrorCode.MEMBER_INACTIVE);
-            }
-
-            // 그 외(ACTIVE, BLOCKED 등)는 이미 가입된 사용자로 처리
+        // 2. 유저가 존재하고(isPresent) && 상태가 ACTIVE인 경우에만 예외 발생
+        if (user.isPresent() && user.get().getStatus() == UserStatus.ACTIVE) {
             throw new GeneralException(ErrorCode.MEMBER_ALREADY_REGISTERED);
         }
 
-        // user가 없으면 중복 아님 -> 통과
+        // 3. 유저가 없거나(신규), 존재하더라도 상태가 INACTIVE(탈퇴)라면
+        // 예외를 던지지 않고 그냥 메서드가 종료됨 -> "통과(OK)"로 간주
     }
 
     /**

--- a/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode implements BaseErrorCode{
     // Member 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "사용자를 찾을 수 없습니다."),
     MEMBER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER409_1", "이미 가입된 사용자입니다."),
+    MEMBER_INACTIVE(HttpStatus.BAD_REQUEST, "MEMBER400_2", "기존에 가입 후 탈퇴한 회원입니다. 재로그인시 회원정보가 복구됩니다."),
     
     // Device 관련 에러
     DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE404", "요청한 기기를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📋 작업 내용
유저가 INACTIVE인 경우 예외 추가
## 🔗 관련 이슈 (Issue)
Closes #92


## 🧪 테스트 결과
## ✅ 체크리스트
- [x] 1 : 유저가 INACTIVE인 경우 예외 추가
- [x] 2 : ErrorCode에 탈퇴한 회원 정보 추가