### PR TITLE
Refactor: Template도메인 Service계층 비즈니스 검증 로직 강화

### DIFF
--- a/src/main/java/com/digital_tok/DigitalTokApplication.java
+++ b/src/main/java/com/digital_tok/DigitalTokApplication.java
@@ -3,9 +3,11 @@ package com.digital_tok;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync // 비동기 처리 활성화
 public class DigitalTokApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode implements BaseErrorCode{
 
     // Template 관련 에러
     TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMPLATE404_1", "해당 템플릿을 찾을 수 없습니다."),
-    ;
+    TEMPLATE_ALREADY_EXISTS(HttpStatus.CONFLICT, "TEMPLATE409_1", "이미 생성된 지하철 역 템플릿입니다.");
     
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/digital_tok/global/apiPayload/code/ErrorCode.java
@@ -35,8 +35,10 @@ public enum ErrorCode implements BaseErrorCode{
 
     // Template 관련 에러
     TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMPLATE404_1", "해당 템플릿을 찾을 수 없습니다."),
-    TEMPLATE_ALREADY_EXISTS(HttpStatus.CONFLICT, "TEMPLATE409_1", "이미 생성된 지하철 역 템플릿입니다.");
-    
+    TEMPLATE_ALREADY_EXISTS(HttpStatus.CONFLICT, "TEMPLATE409_1", "이미 생성된 지하철 역 템플릿입니다."),
+    TEMPLATE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "TEMPLATE500_1", "롤백 중 파일 삭제에 실패했습니다.");
+
+
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/digital_tok/global/config/SecurityConfig.java
+++ b/src/main/java/com/digital_tok/global/config/SecurityConfig.java
@@ -51,6 +51,9 @@ public class SecurityConfig {
                         // 인증 없이 접근 가능한 경로 (로그인, 회원가입, 스웨거 등)
                         .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/health").permitAll()
 
+                        // ADMIN 전용 - 이미지 생성은 관리자만 가능
+                        .requestMatchers("/api/v1/templates/subway/generate").hasRole("ADMIN")
+
                         // 그 외 모든 요청은 인증(로그인) 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/digital_tok/global/event/S3ImageRollbackEvent.java
+++ b/src/main/java/com/digital_tok/global/event/S3ImageRollbackEvent.java
@@ -1,0 +1,4 @@
+package com.digital_tok.global.event;
+
+public record S3ImageRollbackEvent(String fileUrl) {
+}

--- a/src/main/java/com/digital_tok/global/event/S3RollbackEventHandler.java
+++ b/src/main/java/com/digital_tok/global/event/S3RollbackEventHandler.java
@@ -1,0 +1,34 @@
+package com.digital_tok.global.event;
+
+import com.digital_tok.template.service.makeSubwayImage.S3UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3RollbackEventHandler {
+
+    private final S3UploadService s3UploadService;
+
+    @Async // 별도 스레드에서 실행
+    @EventListener
+    public void handleRollback(S3ImageRollbackEvent event) {
+        String fileUrl = event.fileUrl();
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+
+        try {
+            log.info("[Rollback] S3 파일 삭제 시도: {}", fileUrl);
+            s3UploadService.deleteFile(fileUrl);
+            log.info("[Rollback] S3 파일 삭제 성공");
+        } catch (Exception e) {
+            // 삭제 실패 시 로그를 남겨서 나중에 수동으로라도 지울 수 있게 해야 함
+            log.error("[Rollback] S3 파일 삭제 실패 (수동 확인 필요). URL: {}, Error: {}", fileUrl, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/digital_tok/template/controller/SubwayController.java
+++ b/src/main/java/com/digital_tok/template/controller/SubwayController.java
@@ -75,16 +75,13 @@ public class SubwayController implements SubwayControllerDocs{
     @Override
     @PostMapping("/subway/generate")
     @ApiErrorCodes({
+            ErrorCode.TEMPLATE_ALREADY_EXISTS, // 409 (해당 지하철역 템플릿이 이미 존재)
             ErrorCode.IMAGE_UPLOAD_FAIL,      // 500 (S3 업로드 실패)
             ErrorCode.IMAGE_TO_BINARY_ERROR   // 500 (바이너리 변환 실패)
     })
     public ApiResponse<String> createSubwayTemplate(@RequestBody @Valid SubwayCreateRequestDTO request) {
 
-        Long templateId = subwayTemplateUploadService.createAndSaveSubwayTemplate(
-                request.getStationName(),
-                request.getStationNameEng(),
-                request.getLineName()
-        );
+        Long templateId = subwayTemplateUploadService.createAndSaveSubwayTemplate(request);
 
         return ApiResponse.onSuccess(SuccessCode.OK, "성공적으로 생성되었습니다. templateId: " + templateId);
     }

--- a/src/main/java/com/digital_tok/template/controller/SubwayController.java
+++ b/src/main/java/com/digital_tok/template/controller/SubwayController.java
@@ -76,6 +76,7 @@ public class SubwayController implements SubwayControllerDocs{
     @PostMapping("/subway/generate")
     @ApiErrorCodes({
             ErrorCode.TEMPLATE_ALREADY_EXISTS, // 409 (해당 지하철역 템플릿이 이미 존재)
+            ErrorCode.TEMPLATE_DELETE_FAIL, // 500 롤백 중 파일 삭제에 실패했을 때
             ErrorCode.IMAGE_UPLOAD_FAIL,      // 500 (S3 업로드 실패)
             ErrorCode.IMAGE_TO_BINARY_ERROR   // 500 (바이너리 변환 실패)
     })

--- a/src/main/java/com/digital_tok/template/dto/SubwayCreateRequestDTO.java
+++ b/src/main/java/com/digital_tok/template/dto/SubwayCreateRequestDTO.java
@@ -3,11 +3,15 @@ package com.digital_tok.template.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class SubwayCreateRequestDTO {
 
     @NotBlank(message = "역 이름은 필수입니다.")

--- a/src/main/java/com/digital_tok/template/repository/SubwayTemplateRepository.java
+++ b/src/main/java/com/digital_tok/template/repository/SubwayTemplateRepository.java
@@ -1,6 +1,7 @@
 package com.digital_tok.template.repository;
 
 import com.digital_tok.template.domain.SubwayTemplate;
+import com.digital_tok.template.dto.SubwayCreateRequestDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,5 @@ public interface SubwayTemplateRepository extends JpaRepository<SubwayTemplate, 
     // 한글이랑 영어 둘 다 검색가능
     List<SubwayTemplate> findByStationNameContainingOrStationNameEngContainingIgnoreCase(String stationName, String stationNameEng);
 
+    boolean existsByStationNameAndLineName(String stationName, String lineName);
 }

--- a/src/main/java/com/digital_tok/template/service/makeSubwayImage/S3UploadService.java
+++ b/src/main/java/com/digital_tok/template/service/makeSubwayImage/S3UploadService.java
@@ -19,10 +19,10 @@ public class S3UploadService {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
-    // 기존 메서드 (내부에서 범용 메서드 호출하도록 변경)
-    public String upload(byte[] imageBytes, String directoryPath) {
-        return upload(imageBytes, directoryPath, "png", "image/png");
-    }
+//    // 기존 메서드 (내부에서 범용 메서드 호출하도록 변경)
+//    public String upload(byte[] imageBytes, String directoryPath) {
+//        return upload(imageBytes, directoryPath, "png", "image/png");
+//    }
 
     // 확장자와 Content-Type을 지정할 수 있는 범용 업로드 메서드
     public String upload(byte[] fileBytes, String directoryPath, String extension, String contentType) {

--- a/src/main/java/com/digital_tok/template/service/makeSubwayImage/S3UploadService.java
+++ b/src/main/java/com/digital_tok/template/service/makeSubwayImage/S3UploadService.java
@@ -1,5 +1,9 @@
 package com.digital_tok.template.service.makeSubwayImage;
 
+import com.digital_tok.global.apiPayload.code.ErrorCode;
+import com.digital_tok.global.apiPayload.exception.GeneralException;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,10 +12,12 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 
+import java.net.URI;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class S3UploadService {
 
     private final S3Client s3Client;
@@ -49,5 +55,41 @@ public class S3UploadService {
                 .bucket(bucket)
                 .key(fileName)
                 .build()).toExternalForm();
+    }
+
+    /**
+     * S3 파일 삭제 메서드 (롤백용)
+     * @param fileUrl S3 전체 URL (예: https://bucket.s3.region.amazonaws.com/folder/file.png)
+     */
+    public void deleteFile(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+
+        try {
+            // 1. URL에서 Key 추출 ,도메인 제외하고 경로만 가져옴
+            URI uri = new URI(fileUrl);
+            String key = uri.getPath();
+
+            // Key 앞의 '/' 제거 (예: /folder/file.png -> folder/file.png)
+            if (key.startsWith("/")) {
+                key = key.substring(1);
+            }
+
+            // 2. 삭제 요청 생성
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            // 3. 삭제 실행
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 완료: key={}", key);
+
+        } catch (Exception e) {
+            // 삭제 실패 시 에러를 던져서 리스너가 알 수 있게 함 (로그는 리스너에서도 찍음)
+            log.error("S3 파일 삭제 실패: url={}", fileUrl, e);
+            throw new GeneralException(ErrorCode.TEMPLATE_DELETE_FAIL);
+        }
     }
 }

--- a/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateService.java
+++ b/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateService.java
@@ -1,5 +1,7 @@
 package com.digital_tok.template.service.makeSubwayImage;
 
+import com.digital_tok.global.apiPayload.code.ErrorCode;
+import com.digital_tok.global.apiPayload.exception.GeneralException;
 import com.digital_tok.template.domain.SubwayTemplate;
 import com.digital_tok.template.repository.SubwayTemplateRepository;
 import jakarta.transaction.Transactional;
@@ -13,6 +15,11 @@ import org.springframework.stereotype.Service;
 public class SubwayTemplateService { // 생성된 지하철 이미지를 받아서 DB에 저장
     private final SubwayTemplateRepository subwayTemplateRepository;
     public Long saveToDatabase(String nameKor, String nameEng, String lineName, String imageUrl, String dataUrl) {
+
+        // 중복 검사 로직 추가
+        if (subwayTemplateRepository.existsByStationNameAndLineName(nameKor, lineName)) {
+            throw new GeneralException(ErrorCode.TEMPLATE_ALREADY_EXISTS);
+        }
 
         SubwayTemplate subwayTemplate = SubwayTemplate.builder()
                 // 부모(Template) 필드

--- a/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadService.java
+++ b/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadService.java
@@ -2,6 +2,7 @@ package com.digital_tok.template.service.makeSubwayImage;
 
 import com.digital_tok.global.apiPayload.code.ErrorCode;
 import com.digital_tok.global.apiPayload.exception.GeneralException;
+import com.digital_tok.global.event.S3ImageRollbackEvent;
 import com.digital_tok.image.service.processing.EinkBinaryEncoder;
 import com.digital_tok.image.service.processing.EinkEncodingOption;
 import com.digital_tok.image.service.processing.EinkQuantizer;
@@ -9,6 +10,7 @@ import com.digital_tok.template.dto.SubwayCreateRequestDTO;
 import com.digital_tok.template.repository.SubwayTemplateRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.imageio.ImageIO;
@@ -24,34 +26,53 @@ public class SubwayTemplateUploadService { // 이미지 생성 후 S3에 업로�
     private final Eink4ColorService imageGenerator;
     private final S3UploadService s3Uploader;
     private final SubwayTemplateService subwayTemplateService;
+    private final SubwayTemplateRepository subwayTemplateRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 이미지 처리용 객체 생성
     private final EinkEncodingOption encodingOption = new EinkEncodingOption();
     private final EinkQuantizer quantizer = new EinkQuantizer();
     private final EinkBinaryEncoder binaryEncoder = new EinkBinaryEncoder(encodingOption);
 
-    private final SubwayTemplateRepository subwayTemplateRepository;
-
     public Long createAndSaveSubwayTemplate(SubwayCreateRequestDTO request) {
 
-        String nameKor = request.getStationName();
-        String nameEng = request.getStationNameEng();
-        String lineName = request.getLineName();
+        String nameKor = request.getStationName().trim();
+        String nameEng = request.getStationNameEng().trim();
+        String lineName = request.getLineName().trim();
 
         if (subwayTemplateRepository.existsByStationNameAndLineName(nameKor, lineName + "호선")) {
-            throw new GeneralException(ErrorCode.TEMPLATE_ALREADY_EXISTS); // 에러 코드 추가 필요
+            throw new GeneralException(ErrorCode.TEMPLATE_ALREADY_EXISTS);
         }
 
-        // 1. 이미지 생성
-        byte[] imageBytes;
+        byte[] imageBytes = generateImage(nameKor, nameEng, lineName); // 1. 이미지 생성
+        byte[] binaryBytes = generateBinaryData(imageBytes); // 2. 바이너리 데이터 변환
+
+        // 3. S3 업로드
+        String uploadedImageUrl = s3Uploader.upload(imageBytes, "template/subway", "png", "image/png");
+        String uploadedDataUrl = s3Uploader.upload(binaryBytes, "template/subway/binary", "bin", "application/octet-stream");
+
+        // 4. DB 저장 (DB 작업 -> 트랜잭션 -> 별도 호출)
         try {
-            imageBytes = imageGenerator.generatePatternImage(nameKor, nameEng, lineName);
+            return subwayTemplateService.saveToDatabase(nameKor, nameEng, lineName, uploadedImageUrl, uploadedDataUrl);
+        } catch (Exception e) {
+            log.error("DB 저장 실패. S3 롤백 이벤트 발행: {}", uploadedImageUrl);
+            eventPublisher.publishEvent(new S3ImageRollbackEvent(uploadedImageUrl));
+            eventPublisher.publishEvent(new S3ImageRollbackEvent(uploadedDataUrl));
+
+            throw e;
+        }
+    }
+
+    private byte[] generateImage(String nameKor, String nameEng, String lineName) {
+
+        try {
+            return imageGenerator.generatePatternImage(nameKor, nameEng, lineName);
         } catch (IOException e) {
             log.error("지하철 템플릿 이미지 생성 중 오류 발생: {}", e.getMessage(), e);
             throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
         }
-
-        // 2. 바이너리 데이터 변환
+    }
+    private byte[] generateBinaryData(byte[] imageBytes) {
         byte[] binaryBytes;
         try {
             // 2-1. byte[] -> BufferedImage 변환
@@ -69,12 +90,6 @@ public class SubwayTemplateUploadService { // 이미지 생성 후 S3에 업로�
             log.error("바이너리 데이터 변환 중 오류 발생: {}", e.getMessage(), e);
             throw new GeneralException(ErrorCode.IMAGE_TO_BINARY_ERROR);
         }
-
-        // 3. S3 업로드
-        String uploadedImageUrl = s3Uploader.upload(imageBytes, "template/subway", "png", "image/png");
-        String uploadedDataUrl = s3Uploader.upload(binaryBytes, "template/subway/binary", "bin", "application/octet-stream");
-
-        // 4. DB 저장 (DB 작업 -> 트랜잭션 -> 별도 호출)
-        return subwayTemplateService.saveToDatabase(nameKor, nameEng, lineName, uploadedImageUrl, uploadedDataUrl);
+        return binaryBytes;
     }
 }

--- a/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadService.java
+++ b/src/main/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadService.java
@@ -5,6 +5,8 @@ import com.digital_tok.global.apiPayload.exception.GeneralException;
 import com.digital_tok.image.service.processing.EinkBinaryEncoder;
 import com.digital_tok.image.service.processing.EinkEncodingOption;
 import com.digital_tok.image.service.processing.EinkQuantizer;
+import com.digital_tok.template.dto.SubwayCreateRequestDTO;
+import com.digital_tok.template.repository.SubwayTemplateRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +30,17 @@ public class SubwayTemplateUploadService { // 이미지 생성 후 S3에 업로�
     private final EinkQuantizer quantizer = new EinkQuantizer();
     private final EinkBinaryEncoder binaryEncoder = new EinkBinaryEncoder(encodingOption);
 
-    public Long createAndSaveSubwayTemplate(String nameKor, String nameEng, String lineName) {
+    private final SubwayTemplateRepository subwayTemplateRepository;
+
+    public Long createAndSaveSubwayTemplate(SubwayCreateRequestDTO request) {
+
+        String nameKor = request.getStationName();
+        String nameEng = request.getStationNameEng();
+        String lineName = request.getLineName();
+
+        if (subwayTemplateRepository.existsByStationNameAndLineName(nameKor, lineName + "호선")) {
+            throw new GeneralException(ErrorCode.TEMPLATE_ALREADY_EXISTS); // 에러 코드 추가 필요
+        }
 
         // 1. 이미지 생성
         byte[] imageBytes;

--- a/src/test/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadServiceTest.java
+++ b/src/test/java/com/digital_tok/template/service/makeSubwayImage/SubwayTemplateUploadServiceTest.java
@@ -1,0 +1,73 @@
+package com.digital_tok.template.service.makeSubwayImage;
+
+import com.digital_tok.template.dto.SubwayCreateRequestDTO;
+import com.digital_tok.template.repository.SubwayTemplateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class SubwayTemplateUploadServiceTest {
+
+    @Autowired
+    private SubwayTemplateUploadService subwayTemplateUploadService;
+
+    @MockitoBean
+    private S3UploadService s3UploadService;
+    @MockitoBean
+    private Eink4ColorService eink4ColorService;
+    @MockitoBean
+    private SubwayTemplateRepository subwayTemplateRepository;
+    @MockitoBean
+    private SubwayTemplateService subwayTemplateService;
+
+    @Test
+    @DisplayName("이미지 생성 후 DB 저장 실패 시 S3 파일 삭제(롤백) 메서드가 호출되어야 한다")
+    void rollbackTest() throws Exception {
+        // given
+        String fakeUrl = "https://s3.aws.com/test.png";
+
+        // 1. 이미지 데이터 생성
+        BufferedImage mockImage = new BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(mockImage, "png", baos);
+        byte[] validImageBytes = baos.toByteArray(); // 유효한 PNG 바이트 배열
+
+        given(eink4ColorService.generatePatternImage(any(), any(), any()))
+                .willReturn(validImageBytes);
+
+        given(s3UploadService.upload(any(byte[].class), any(), any(), any()))
+                .willReturn(fakeUrl);
+
+        doThrow(new RuntimeException("DB 저장 실패"))
+                .when(subwayTemplateService)
+                .saveToDatabase(any(), any(), any(), any(), any());
+
+        // when
+        try {
+            SubwayCreateRequestDTO request = SubwayCreateRequestDTO.builder()
+                    .stationName("강남")
+                    .stationNameEng("gangnam")
+                    .lineName("2")
+                    .build();
+
+            subwayTemplateUploadService.createAndSaveSubwayTemplate(request);
+        } catch (Exception e) {
+            System.out.println("예상된 에러 발생: " + e.getMessage());
+        }
+
+        // then
+        verify(s3UploadService, timeout(2000).times(2)).deleteFile(fakeUrl);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,61 @@
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+  # 1. DB를 H2(인메모리)로 변경
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # 2. JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    defer-datasource-initialization: true
+
+  # 3. AWS S3 설정 (가짜 값)
+  cloud:
+    aws:
+      s3:
+        bucket: test-bucket
+      region:
+        static: ap-northeast-2
+      stack:
+        auto: false
+      credentials:
+        access-key: TEST_ACCESS_KEY
+        secret-key: TEST_SECRET_KEY
+
+  # 4. 이메일 설정 (가짜 값)
+  mail:
+    host: localhost
+    port: 587
+    username: test@email.com
+    password: test_password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
+# 5. 커스텀 설정
+storage:
+  type: s3
+
+# 6. JWT 설정 (★수정됨★)
+# 유효한 Base64 문자열로 변경 (밑줄_ 없음, +, / 사용)
+jwt:
+  # "ThisIsATestSecretKeyForDigitalTokServerProject123"를 Base64로 인코딩한 값입니다.
+  secret: VGhpc0lzQVRlc3RTZWNyZXRLZXlGb3JEaWdpdGFsVG9rU2VydmVyUHJvamVjdDEyMw==
+  access-token-validity-in-seconds: 3600
+  refresh-token-validity-in-seconds: 1209600


### PR DESCRIPTION
## 📋 작업 내용
Refactor: 이미 생성된 지하철 역 템플릿 생성 못하게 예외처리
S3에 이미지 업로드 후 DB에 저장할때, 만약 DB에 저장이 실패하면 S3에 저장한 이미지를 삭제

## 🔗 관련 이슈 (Issue)
Closes #81
