### PR TITLE
Refactor: 이미지 업로드 API 성능개선 리펙토링

### DIFF
--- a/ec2-loadtest-images.js
+++ b/ec2-loadtest-images.js
@@ -1,0 +1,70 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// 1. 테스트에 사용할 이미지 파일을 미리 로드합니다. (스크립트와 같은 경로에 이미지 파일 필요)
+const binFile = open('./Redis.png', 'b');
+
+export const options = {
+    vus: 15,
+    duration: '30s',
+};
+
+export function setup() {
+    const loginUrl = 'https://www.diring.site/api/v1/auth/login';
+    const payload = JSON.stringify({
+        email: 'user@example.com',
+        password: 'string',
+    });
+
+    const params = {
+        headers: { 'Content-Type': 'application/json' },
+    };
+
+    const res = http.post(loginUrl, payload, params);
+
+    if (res.status !== 200 || !res.body) {
+        console.error('로그인 실패');
+        return { token: null };
+    }
+
+    try {
+        const responseBody = res.json();
+        if (responseBody && responseBody.result && responseBody.result.accessToken) {
+            return { token: responseBody.result.accessToken };
+        }
+    } catch (e) {
+        console.error(`JSON 파싱 실패: ${e.message}`);
+    }
+
+    return { token: null };
+}
+
+export default function (data) {
+    if (!data || !data.token) return;
+
+    // 2. API 경로 설정 (imageName은 쿼리 파라미터로 전달)
+    const url = 'https://www.diring.site/api/v1/images?imageName=k6_test_image';
+
+    // 3. multipart/form-data 본문 구성
+    const formData = {
+        file: http.file(binFile, 'test-image.jpg', 'image/jpeg'),
+    };
+
+    const params = {
+        headers: {
+            'Authorization': `Bearer ${data.token}`,
+            // k6는 본문 데이터가 객체일 경우 자동으로 boundary를 포함한 multipart/form-data를 설정합니다.
+        },
+    };
+
+    // 4. POST 요청 전송
+    const res = http.post(url, formData, params);
+
+    // 5. 응답 확인
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'has result': (r) => r.json().result !== undefined,
+    });
+
+    sleep(1);
+}

--- a/ec2-loadtest-images.js
+++ b/ec2-loadtest-images.js
@@ -5,7 +5,7 @@ import { check, sleep } from 'k6';
 const binFile = open('./Redis.png', 'b');
 
 export const options = {
-    vus: 15,
+    vus: 10,
     duration: '30s',
 };
 

--- a/ec2-loadtest.js
+++ b/ec2-loadtest.js
@@ -2,7 +2,7 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-    vus: 10,
+    vus: 100,
     duration: '30s',
 };
 

--- a/src/main/java/com/digital_tok/global/AmazonS3Manager.java
+++ b/src/main/java/com/digital_tok/global/AmazonS3Manager.java
@@ -54,6 +54,35 @@ public class AmazonS3Manager {
             throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
         }
     }
+
+    public String uploadFile(String keyName, byte[] fileBytes, String contentType, String extension) {
+        // 1. 저장할 경로(Key) 생성
+        String s3Key = keyName + "/" + UUID.randomUUID() + extension;
+
+        try {
+            // 2. PutObjectRequest 생성
+            PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .contentType(contentType)
+                    .build();
+
+            // 3. RequestBody.fromBytes()를 사용하여 업로드
+            // InputStream 대신 이미 메모리에 있는 byte[]를 그대로 사용합니다.
+            s3Client.putObject(req, RequestBody.fromBytes(fileBytes));
+
+            // 4. 업로드된 파일의 URL 반환
+            return s3Client.utilities().getUrl(GetUrlRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .build()).toExternalForm();
+
+        } catch (Exception e) {
+            log.error("S3 byte[] 업로드 중 에러 발생: {}", e.getMessage());
+            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+    }
+
     // preview/bin 파생 업로드용 (새로 추가)
     public String uploadBytes(String s3Key, byte[] bytes, String contentType) {
         try {

--- a/src/main/java/com/digital_tok/image/domain/Image.java
+++ b/src/main/java/com/digital_tok/image/domain/Image.java
@@ -40,8 +40,20 @@ public class Image {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    // 이미지 정합성을 위해 추가
+    @Column(name = "image_status")
+    @Enumerated(EnumType.STRING)
+    private ImageStatus status;
+
     // 지하철 템플릿 ID (FK)-삭제
 
+    // 업로드 완료 및 상태 업데이트 메서드
+    public void completeUpload(String originalUrl, String previewUrl, String einkDataUrl, ImageStatus status) {
+        this.originalUrl = originalUrl;
+        this.previewUrl = previewUrl;
+        this.einkDataUrl = einkDataUrl;
+        this.status = status;
+    }
 
     public void updatePreviewUrl(String previewUrl) {
         this.previewUrl = previewUrl;

--- a/src/main/java/com/digital_tok/image/domain/ImageStatus.java
+++ b/src/main/java/com/digital_tok/image/domain/ImageStatus.java
@@ -1,0 +1,5 @@
+package com.digital_tok.image.domain;
+
+public enum ImageStatus {
+    PENDING, COMPLETED, FAILED
+}

--- a/src/main/java/com/digital_tok/image/handler/ImageProcessEvent.java
+++ b/src/main/java/com/digital_tok/image/handler/ImageProcessEvent.java
@@ -1,0 +1,15 @@
+package com.digital_tok.image.handler;
+
+
+/**
+ * 이미지 처리를 위한 이벤트 객체
+ * @param imageId      DB에 저장된 Image 엔티티의 ID
+ * @param fileBytes    파일의 바이너리 데이터 (비동기 처리를 위해 메모리에 보관)
+ * @param contentType  파일의 확장자/타입 (S3 업로드 시 필요)
+ */
+public record ImageProcessEvent(
+        Long imageId,
+        byte[] fileBytes,
+        String contentType,
+        String extension
+) {}

--- a/src/main/java/com/digital_tok/image/handler/ImageProcessListener.java
+++ b/src/main/java/com/digital_tok/image/handler/ImageProcessListener.java
@@ -1,0 +1,68 @@
+package com.digital_tok.image.handler;
+
+import com.digital_tok.global.AmazonS3Manager;
+import com.digital_tok.image.domain.ImageStatus;
+import com.digital_tok.image.repository.ImageRepository;
+import com.digital_tok.image.service.ImageDerivationService;
+import com.digital_tok.image.service.ImageUpdateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.ByteArrayInputStream;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageProcessListener {
+
+    private final AmazonS3Manager s3Manager;
+    private final ImageDerivationService imageDerivationService;
+    private final ImageUpdateService imageUpdateService;
+    private final ImageRepository imageRepository;
+
+    @Async // 사용자는 기다리지 않게 비동기 처리
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleImageProcess(ImageProcessEvent event) {
+        Long imageId = event.imageId();
+
+        try {
+            // 1. S3 업로드 (기존 로직)
+//            String originalUrl = s3Manager.uploadFile("images", event.getFile());
+            String originalUrl = s3Manager.uploadFile("images", event.fileBytes(), event.contentType(), event.extension());
+//             TODO: Argument 개수 수정필요, 오버로딩 하면 될듯?
+
+            // 2. e-ink 파생 생성 (기존 fallback 정책 유지)
+            ImageDerivationService.Result derived;
+            try {
+                derived = imageDerivationService.derive(new ByteArrayInputStream(event.fileBytes()));
+            } catch (Exception e) {
+                log.warn("Derive failed for imageId={}, fallback to original", imageId);
+                derived = new ImageDerivationService.Result(null, null);
+            }
+
+            // 3. 최종 결과 DB 업데이트 (새로운 트랜잭션)
+            imageUpdateService.updateImageStatus(imageId, originalUrl, derived, ImageStatus.COMPLETED);
+
+        } catch (Exception e) {
+            log.error("Critical error in image processing for imageId={}", imageId, e);
+            imageUpdateService.updateImageStatus(imageId, null, null, ImageStatus.FAILED);
+        }
+    }
+
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
+//    public void updateImageStatus(Long id, String originalUrl, ImageDerivationService.Result derived, ImageStatus status) {
+//        Image image = imageRepository.findById(id).orElseThrow();
+//
+//        // 기존 필드 업데이트 로직
+//        String previewUrl = (derived.previewUrl() != null) ? derived.previewUrl() : originalUrl;
+//
+//        image.completeUpload(originalUrl, previewUrl, derived.einkDataUrl(), status);
+//        imageRepository.save(image);
+//    }
+
+
+}

--- a/src/main/java/com/digital_tok/image/service/ImageService.java
+++ b/src/main/java/com/digital_tok/image/service/ImageService.java
@@ -5,82 +5,52 @@ import com.digital_tok.global.apiPayload.code.ErrorCode;
 import com.digital_tok.global.apiPayload.exception.GeneralException;
 import com.digital_tok.image.domain.Image;
 import com.digital_tok.image.domain.ImageMapping;
+import com.digital_tok.image.handler.ImageProcessEvent;
 import com.digital_tok.image.repository.ImageMappingRepository;
 import com.digital_tok.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.ByteArrayInputStream;
+import com.digital_tok.image.domain.ImageStatus;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ImageService {
 
     private final ImageRepository imageRepository;
     private final ImageMappingRepository imageMappingRepository;
-    private final AmazonS3Manager s3Manager;
-    private final ImageDerivationService imageDerivationService;
+    private final ApplicationEventPublisher eventPublisher;
+//    private final AmazonS3Manager s3Manager;
+//    private final ImageDerivationService imageDerivationService;
 
     /**
      * 이미지 업로드: S3 업로드 + DB(image, image_mapping) 저장
      */
+    @Transactional
     public UploadResult uploadImage(MultipartFile file, String imageName, Long userId) {
 
         // param validation
-        if (file == null || file.isEmpty() || imageName == null || imageName.isBlank() || userId == null) {
-            throw new GeneralException(ErrorCode.IMAGE_BAD_REQUEST);
-        }
-
-        byte[] originalBytes;
-        try {
-            originalBytes = file.getBytes();
-        } catch (Exception e) {
-            log.warn("Failed to read uploaded file bytes. imageName={}, userId={}", imageName, userId, e);
-            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
-        }
-
-        // 1) S3 업로드 (원본)
-        String originalUrl;
-        try {
-            originalUrl = s3Manager.uploadFile("images", file);
-        } catch (Exception e) {
-            log.error("S3 upload failed. imageName={}, userId={}", imageName, userId, e);
-            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
-        }
-
-        // 2) e-ink 파생 생성 (실패해도 업로드 성공 유지: fallback 정책)
-        ImageDerivationService.Result derived;
-        try {
-            derived = imageDerivationService.derive(new ByteArrayInputStream(originalBytes));
-            log.info("Derived eink assets done. previewUrl={}, einkDataUrl={}", derived.previewUrl(), derived.einkDataUrl());
-        } catch (Exception e) {
-            // 정책: 파생 실패해도 업로드 자체는 성공시키고 fallback
-            log.warn("Derive eink assets failed. fallback to originalUrl. imageName={}, userId={}", imageName, userId, e);
-            derived = new ImageDerivationService.Result(null, null);
-            // strict 정책으로 가려면 아래 주석 해제
-            // throw new GeneralException(ErrorCode.IMAGE_DERIVE_FAIL);
-        }
+        validateParam(file, imageName, userId);
 
         LocalDateTime now = LocalDateTime.now();
 
+        // 2. Image 객체 생성
         Image image = Image.builder()
-                .originalUrl(originalUrl)
-                .previewUrl(derived.previewUrl() != null ? derived.previewUrl() : originalUrl)
-                .einkDataUrl(derived.einkDataUrl())
                 .imageName(imageName)
+                .status(ImageStatus.PENDING) // 초기 상태: PENDING
                 .createdAt(now)
                 .deletedAt(null)
                 .build();
-
         imageRepository.save(image);
 
+        // 3. ImageMapping 객체 생성
         ImageMapping mapping = ImageMapping.builder()
                 .userId(userId)
                 .image(image)
@@ -88,13 +58,84 @@ public class ImageService {
                 .savedAt(now)
                 .lastUsedAt(now)
                 .build();
-
         imageMappingRepository.save(mapping);
 
-        log.info("Saved image & mapping. imageId={}, userImageId={}, userId={}",
-                image.getImageId(), mapping.getUserImageId(), userId);
+        // 4. 비즈니스 로직(S3, Derivation)은 이벤트로 위임, 파일의 바이너리를 이벤트에 담아 보냄
+        try {
+            byte[] fileBytes = file.getBytes();
+            String fileName = file.getOriginalFilename();
+            String extension = (fileName != null && fileName.contains("."))
+                    ? fileName.substring(fileName.lastIndexOf("."))
+                    : "";
+            eventPublisher.publishEvent(new ImageProcessEvent(image.getImageId(), fileBytes, file.getContentType(), extension));
+        } catch (IOException e) {
+            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
+        }
+
+        log.info("Image upload initialized. imageId={}, userId={}", image.getImageId(), userId);
+//        byte[] originalBytes;
+//        try {
+//            originalBytes = file.getBytes();
+//        } catch (Exception e) {
+//            log.warn("Failed to read uploaded file bytes. imageName={}, userId={}", imageName, userId, e);
+//            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
+//        }
+//
+//        // 1) S3 업로드 (원본)
+//        String originalUrl;
+//        try {
+//            originalUrl = s3Manager.uploadFile("images", file);
+//        } catch (Exception e) {
+//            log.error("S3 upload failed. imageName={}, userId={}", imageName, userId, e);
+//            throw new GeneralException(ErrorCode.IMAGE_UPLOAD_FAIL);
+//        }
+//
+//        // 2) e-ink 파생 생성 (실패해도 업로드 성공 유지: fallback 정책)
+//        ImageDerivationService.Result derived;
+//        try {
+//            derived = imageDerivationService.derive(new ByteArrayInputStream(originalBytes));
+//            log.info("Derived eink assets done. previewUrl={}, einkDataUrl={}", derived.previewUrl(), derived.einkDataUrl());
+//        } catch (Exception e) {
+//            // 정책: 파생 실패해도 업로드 자체는 성공시키고 fallback
+//            log.warn("Derive eink assets failed. fallback to originalUrl. imageName={}, userId={}", imageName, userId, e);
+//            derived = new ImageDerivationService.Result(null, null);
+//            // strict 정책으로 가려면 아래 주석 해제
+//            // throw new GeneralException(ErrorCode.IMAGE_DERIVE_FAIL);
+//        }
+//
+//
+//        Image image = Image.builder()
+//                .originalUrl(originalUrl)
+//                .previewUrl(derived.previewUrl() != null ? derived.previewUrl() : originalUrl)
+//                .einkDataUrl(derived.einkDataUrl())
+//                .imageName(imageName)
+//                .createdAt(now)
+//                .deletedAt(null)
+//                .build();
+//
+//        imageRepository.save(image);
+//
+//        ImageMapping mapping = ImageMapping.builder()
+//                .userId(userId)
+//                .image(image)
+//                .isFavorite(false)
+//                .savedAt(now)
+//                .lastUsedAt(now)
+//                .build();
+//
+//        imageMappingRepository.save(mapping);
+//
+//        log.info("Saved image & mapping. imageId={}, userImageId={}, userId={}",
+//                image.getImageId(), mapping.getUserImageId(), userId);
 
         return new UploadResult(image, mapping);
+    }
+
+    // 이미지 validate 판단, invalide 시 Exception
+    private void validateParam(MultipartFile file, String imageName, Long userId) {
+        if (file == null || file.isEmpty() || imageName == null || imageName.isBlank() || userId == null) {
+            throw new GeneralException(ErrorCode.IMAGE_BAD_REQUEST);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/digital_tok/image/service/ImageUpdateService.java
+++ b/src/main/java/com/digital_tok/image/service/ImageUpdateService.java
@@ -1,0 +1,31 @@
+package com.digital_tok.image.service;
+
+import com.digital_tok.image.domain.Image;
+import com.digital_tok.image.domain.ImageStatus;
+import com.digital_tok.image.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUpdateService {
+
+    private final ImageRepository imageRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateImageStatus(Long id, String originalUrl, ImageDerivationService.Result derived, ImageStatus status) {
+        Image image = imageRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Image not found: " + id));
+
+        // 파생 데이터가 있으면 사용하고, 없으면 원본 URL을 프리뷰로 사용 (Fallback 정책)
+        String previewUrl = (derived != null && derived.previewUrl() != null)
+                ? derived.previewUrl()
+                : originalUrl;
+
+        String einkDataUrl = (derived != null) ? derived.einkDataUrl() : null;
+
+        image.completeUpload(originalUrl, previewUrl, einkDataUrl, status);
+    }
+}


### PR DESCRIPTION
## 📋 작업 내용
# ImageUpload 리펙토링

기존의 `uploadImage`  메서드는 하나의 단일 Transaction 내부에서 S3업로드 및 BinaryData 생성, DB저장 작업까지 한번에 처리해서 과도한 DB커넥션을 잡고있었음.

1. `uploadImage`  메서드에서는 임시 Image, ImageMapping 객체를 생성하고 저장함
2. 비즈니스 로직은 `eventPublisher.publishEvent`  를 통해 이벤트를 발행시켜서 `ImageProcessListener`로 비즈니스 로직을 위임한다.
3. `ImageProcessListener` 의 `handleImageProcess` 에서 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 옵션을 통해 `uploadImage`  의 Transaction이 commit 된 후에 S3업로드 로직을 수행하게 한다(CallBack 객체 등록하는방식). (+ Async 를 통해 비동기로 처리)
4. Self-Invocation 문제때문에 DB에 업데이트하는 로직은 `ImageUpdateService` 를 통해 따로 처리한다.
5. `ImageUpdateService` 에서 `@Transactional(propagation = Propagation.REQUIRES_NEW)` 처리를 통해 DB 커넥션 풀에서 새로운 DB커넥션을 가져와서 트랜잭션을 연다.
6. S3 URL과 가공된 데이터 주소를 채워 넣고 Image의 상태를 `COMPLETED`(또는 실패 시 `FAILED`)로 변경한다.

1, 2번 과정을 수행하면서 짧게 DB 커넥션을 점유하고, 5번 로직을 수행하면서도 짧게 DB커넥션을 점유한다.

기존에 길~~~게 하나의 DB 커넥션을 점유하는것이 아닌, 짧게 DB커넥션을 점유하면서도 사용자에게 응답은 빠르게 할 수 있게 비동기로 처리하도록 리펙토링했다.

## 🔗 관련 이슈 (Issue)
Closes #101 


## 🧪 테스트 결과
## ✅ 체크리스트
- [ ] 1 : 이미지 업로드 정상작동 확인
- [ ] 2 : local 부하테스트 통과